### PR TITLE
Update NREL 2.8MW from OpenFAST 2.6.0 to 3.1.0

### DIFF
--- a/IEA-scaled/NREL-2.8-127/OpenFAST/NREL-2p8-127.fst
+++ b/IEA-scaled/NREL-2.8-127/OpenFAST/NREL-2p8-127.fst
@@ -18,6 +18,17 @@ False                  Echo        - Echo input data to <RootName>.ech (flag)
 0                      CompSub     - Compute sub-structural dynamics (switch) {0=None; 1=SubDyn; 2=External Platform MCKF}
 0                      CompMooring - Compute mooring system (switch) {0=None; 1=MAP++; 2=FEAMooring; 3=MoorDyn; 4=OrcaFlex}
 0                      CompIce     - Compute ice loads (switch) {0=None; 1=IceFloe; 2=IceDyn}
+0   		       MHK         - MHK turbine type (switch) {0=Not an MHK turbine; 1=Fixed MHK turbine; 2=Floating MHK turbine}
+---------------------- ENVIRONMENTAL CONDITIONS --------------------------------
+9.80665                Gravity     - Gravitational acceleration (m/s^2)
+1.225                  AirDens     - Air density (kg/m^3)
+0                      WtrDens     - Water density (kg/m^3)
+1.464E-05              KinVisc     - Kinematic viscosity of working fluid (m^2/s)
+335                    SpdSound    - Speed of sound in working fluid (m/s)
+103500                 Patm        - Atmospheric pressure (Pa) [used only for an MHK turbine cavitation check]
+1700                   Pvap        - Vapour pressure of working fluid (Pa) [used only for an MHK turbine cavitation check]
+0                      WtrDpth     - Water depth (m)
+0                      MSL2SWL     - Offset between still-water level and mean sea level (m) [positive upward]
 ---------------------- INPUT FILES ---------------------------------------------
 "NREL-2p8-127_ElastoDyn.dat" EDFile      - Name of file containing ElastoDyn input parameters (quoted string)
 "none"                 BDBldFile(1) - Name of file containing BeamDyn input parameters for blade 1 (quoted string)

--- a/IEA-scaled/NREL-2.8-127/OpenFAST/NREL-2p8-127_AeroDyn15.dat
+++ b/IEA-scaled/NREL-2.8-127/OpenFAST/NREL-2p8-127_AeroDyn15.dat
@@ -13,12 +13,11 @@ False                  CavitCheck  - Perform cavitation check? (flag) [AFAeroMod
 False                  CompAA      - Flag to compute AeroAcoustics calculation [only used when WakeMod=1 or 2]
 AeroAcousticsInput.dat AA_InputFile - AeroAcoustics input file [used only when CompAA=true]
 ======  Environmental Conditions  ===================================================================
- 1.225000000000000e+00 AirDens     - Air density (kg/m^3)
- 1.477551020408163e-05 KinVisc     - Kinematic air viscosity (m^2/s)
- 3.400000000000000e+02 SpdSound    - Speed of sound (m/s)
- 1.035000000000000e+05 Patm        - Atmospheric pressure (Pa) [used only when CavitCheck=True]
- 1.700000000000000e+03 Pvap        - Vapour pressure of fluid (Pa) [used only when CavitCheck=True]
- 5.000000000000000e-01 FluidDepth  - Water depth above mid-hub height (m) [used only when CavitCheck=True]
+"default"     AirDens            - Air density (kg/m^3)
+"default"     KinVisc            - Kinematic air viscosity (m^2/s)
+"default"     SpdSound           - Speed of sound (m/s)
+"default"     Patm               - Atmospheric pressure (Pa) [used only when CavitCheck=True]
+"default"     Pvap               - Vapour pressure of fluid (Pa) [used only when CavitCheck=True]
 ======  Blade-Element/Momentum Theory Options  ====================================================== [used only when WakeMod=1]
 2                      SkewMod     - Type of skewed-wake correction model (switch) {1=uncoupled, 2=Pitt/Peters, 3=coupled} [unused when WakeMod=0 or 3]
 1.4726215563702154     SkewModFactor - Constant used in Pitt/Peters skewed wake model {or "default" is 15/32*pi} (-) [used only when SkewMod=2; unused when WakeMod=0 or 3]

--- a/IEA-scaled/NREL-2.8-127/OpenFAST/NREL-2p8-127_ElastoDyn.dat
+++ b/IEA-scaled/NREL-2.8-127/OpenFAST/NREL-2p8-127_ElastoDyn.dat
@@ -4,8 +4,6 @@ Generated with AeroElasticSE FAST driver
 False                  Echo        - Echo input data to "<RootName>.ech" (flag)
 3                      Method      - Integration method: {1: RK4, 2: AB4, or 3: ABM4} (-)
 default                DT          Integration time step (s)
----------------------- ENVIRONMENTAL CONDITION ---------------------------------
-9.81                   Gravity     - Gravitational acceleration (m/s^2)
 ---------------------- DEGREES OF FREEDOM --------------------------------------
 True                   FlapDOF1    - First flapwise blade mode DOF (flag)
 True                   FlapDOF2    - Second flapwise blade mode DOF (flag)

--- a/IEA-scaled/NREL-2.8-127/OpenFAST/NREL-2p8-127_ServoDyn.dat
+++ b/IEA-scaled/NREL-2.8-127/OpenFAST/NREL-2p8-127_ServoDyn.dat
@@ -57,11 +57,22 @@ True                   GenTiStp    - Method to stop the generator {T: timed usin
 99999.0                TYawManS    - Time to start override yaw maneuver and end standard yaw control (s)
 0.25                   YawManRat   - Yaw maneuver rate (in absolute value) (deg/s)
 0.0                    NacYawF     - Final yaw angle for override yaw maneuvers (degrees)
----------------------- TUNED MASS DAMPER ---------------------------------------
-False                  CompNTMD    - Compute nacelle tuned mass damper {true/false} (flag)
-"none"                 NTMDfile    - Name of the file for nacelle tuned mass damper (quoted string) [unused when CompNTMD is false]
-False                  CompTTMD    - Compute tower tuned mass damper {true/false} (flag)
-"none"                 TTMDfile    - Name of the file for tower tuned mass damper (quoted string) [unused when CompTTMD is false]
+---------------------- AERODYNAMIC FLOW CONTROL --------------------------------
+0                      AfCmode      - Airfoil control mode {0: none, 1: cosine wave cycle, 4: user-defined from Simulink/Labview, 5: user-defined from Bladed-style DLL} (switch)
+0                      AfC_Mean     - Mean level for cosine cycling or steady value (-) [used only with AfCmode==1]
+0                      AfC_Amp      - Amplitude for for cosine cycling of flap signal (-) [used only with AfCmode==1]
+0                      AfC_Phase    - Phase relative to the blade azimuth (0 is vertical) for for cosine cycling of flap signal (deg) [used only with AfCmode==1]
+---------------------- STRUCTURAL CONTROL --------------------------------------
+0                      NumBStC      - Number of blade structural controllers (integer)
+"unused"               BStCfiles    - Name of the files for blade structural controllers (quoted strings) [unused when NumBStC==0]
+0                      NumNStC      - Number of nacelle structural controllers (integer)
+"unused"               NStCfiles    - Name of the files for nacelle structural controllers (quoted strings) [unused when NumNStC==0]
+0                      NumTStC      - Number of tower structural controllers (integer)
+"unused"               TStCfiles    - Name of the files for tower structural controllers (quoted strings) [unused when NumTStC==0]
+0                      NumSStC      - Number of substructure structural controllers (integer)
+"unused"               SStCfiles    - Name of the files for substructure structural controllers (quoted strings) [unused when NumSStC==0]
+---------------------- CABLE CONTROL -------------------------------------------
+0                      CCmode       - Cable control mode {0: none, 4: user-defined from Simulink/Labview, 5: user-defined from Bladed-style DLL} (switch)
 ---------------------- BLADED INTERFACE ---------------------------------------- [used only with Bladed Interface]
 "/home/equon/WEIS/local/lib/libdiscon.so" DLL_FileName - Name/location of the dynamic library {.dll [Windows] or .so [Linux]} in the Bladed-DLL format (-) [used only with Bladed Interface]
 "NREL-2p8-127_DISCON.IN" DLL_InFile  - Name of input file sent to the DLL (-) [used only with Bladed Interface]


### PR DESCRIPTION
Update this turbine model to be compatible with OpenFAST 3.1.0. These updates are based on Lawrence's [notes](https://github.com/lawrenceccheung/amrwind-frontend/blob/afbc1dd284095ee869ba8a9cd3760fdf8b08ca82/docs/openfast_turbine.md#going-from-openfast-v26-to-v300). This turbine has been tested as part of an AMR-Wind simulation, and AMR-Wind successfully ran with it (after making some AMR-Wind specific tweaks like to `WakeMod`).